### PR TITLE
Updating dependencies and other general updates to the package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,8 +13,8 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[package.json]
+indent_size = 2
+
 [*.md]
 trim_trailing_whitespace = false
-
-[Markdown]
-indent_style = tab

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "grunt": "0.4.5",
     "grunt-complexity": "0.2.0",
     "grunt-contrib-jshint": "0.10.0",
-    "grunt-mocha-test": "0.11.0",
-    "mocha": "1.21.0"
+    "grunt-mocha-test": "0.11.0"
   },
   "engines": {
     "node": ">=0.10.21",

--- a/package.json
+++ b/package.json
@@ -1,49 +1,49 @@
 {
-    "name": "log-notify",
-    "version": "0.2.0",
-    "author": "James Young <jmeyoung@gmail.com> (http://jamsyoung.com)",
-    "description": "An override for console.log that also sends notifications to OS X Notification Center and Growl",
-    "main": "log-notify.js",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/jamsyoung/log-notify"
-    },
-    "bugs": {
-        "url": "https://github.com/jamsyoung/log-notify/issues",
-        "email": "jmeyoung@gmail.com"
-    },
-    "scripts": {
-        "test": "grunt test"
-    },
-    "dependencies": {
-        "debug": "0.7.4",
-        "growl": "1.7.0",
-        "terminal-notifier": "0.1.2"
-    },
-    "devDependencies": {
-        "chai": "1.8.1",
-        "grunt": "0.4.1",
-        "grunt-complexity": "0.1.3",
-        "grunt-contrib-jshint": "0.7.0",
-        "grunt-mocha-test": "0.7.0",
-        "mocha": "1.13.0"
-    },
-    "engines": {
-        "node": ">=0.10.21",
-        "npm": ">=1.3.11"
-    },
-    "keywords": [
-        "growl",
-        "log",
-        "log-notify",
-        "notification center",
-        "notification-center",
-        "notify",
-        "notify-send",
-        "terminal-notifier"
-    ],
-    "license": {
-        "type": "MIT",
-        "url": "https://github.com/jamsyoung/log-notify/blob/master/LICENSE.md"
-    }
+  "name": "log-notify",
+  "version": "0.2.0",
+  "author": "James Young <jmeyoung@gmail.com> (http://jamsyoung.com)",
+  "description": "An override for console.log that also sends notifications to OS X Notification Center and Growl",
+  "main": "log-notify.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jamsyoung/log-notify"
+  },
+  "bugs": {
+    "url": "https://github.com/jamsyoung/log-notify/issues",
+    "email": "jmeyoung@gmail.com"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "dependencies": {
+    "debug": "0.7.4",
+    "growl": "1.7.0",
+    "terminal-notifier": "0.1.2"
+  },
+  "devDependencies": {
+    "chai": "1.8.1",
+    "grunt": "0.4.1",
+    "grunt-complexity": "0.1.3",
+    "grunt-contrib-jshint": "0.7.0",
+    "grunt-mocha-test": "0.7.0",
+    "mocha": "1.13.0"
+  },
+  "engines": {
+    "node": ">=0.10.21",
+    "npm": ">=1.3.11"
+  },
+  "keywords": [
+    "growl",
+    "log",
+    "log-notify",
+    "notification center",
+    "notification-center",
+    "notify",
+    "notify-send",
+    "terminal-notifier"
+  ],
+  "license": {
+    "type": "MIT",
+    "url": "https://github.com/jamsyoung/log-notify/blob/master/LICENSE.md"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
     "terminal-notifier": "0.1.2"
   },
   "devDependencies": {
-    "chai": "1.8.1",
-    "grunt": "0.4.1",
-    "grunt-complexity": "0.1.3",
-    "grunt-contrib-jshint": "0.7.0",
-    "grunt-mocha-test": "0.7.0",
-    "mocha": "1.13.0"
+    "chai": "1.9.1",
+    "grunt": "0.4.5",
+    "grunt-complexity": "0.2.0",
+    "grunt-contrib-jshint": "0.10.0",
+    "grunt-mocha-test": "0.11.0",
+    "mocha": "1.21.0"
   },
   "engines": {
     "node": ">=0.10.21",

--- a/test/mocha/log-notify.test.js
+++ b/test/mocha/log-notify.test.js
@@ -1,4 +1,4 @@
-/* global describe, it */
+/* jshint mocha: true */
 'use strict';
 
 // I haven't found a good way to actually confirm that the notification was


### PR DESCRIPTION
Closes #7 
- chai-1.8.1 -> 1.9.1
- grunt-0.4.1 -> 0.4.5
- grunt-complexity-0.1.3 -> 0.2.0
- grunt-contrib-jshint-0.7.0 -> 0.10.0
- grunt-mocha-test-0.7.0 -> 0.11.0
- mocha-1.13.0 -> 1.21.0
